### PR TITLE
xbps usage: added archive mirror and glibc/musl prefix with usage exa…

### DIFF
--- a/usage/xbps/index.markdown
+++ b/usage/xbps/index.markdown
@@ -92,10 +92,17 @@ After installing any of them don't forget to synchronize the repository data:
 
 #### Archives
 
-Repository archives are available at http://archive.voidlinux.eu/YYYY-MM-DD, where
-the datestamp is the date of the archive you wish to use as a repository.
+Repository archives are available at 
 
-    $ xbps-query --repository=http://archive.voidlinux.eu/2015-02-27/current -Mis \*
+* http://archive.voidlinux.eu (Paris, FR - primary)
+* http://archive.voidlinux.com (California, US - mirror)
+
+Archive repository URIs would be http://archive.voidlinux.eu/musl/YYYY-MM-DD, where
+the datestamp is the date of the archive you wish to use as a repository, and either musl
+or glibc as the prefix directory.
+
+    $ xbps-query --repository=http://archive.voidlinux.eu/glibc/2015-06-15/current -Mis \*
+    $ xbps-query --repository=http://archive.voidlinux.com/musl/2015-06-14/current -Mis \*
 
 To list all packages stored on that repository.
 


### PR DESCRIPTION
…mples

Also need to move the CNAME for archive.voidlinux.eu to point to paris.voidlinux.net to match the documentation.