### PR TITLE
Apply text alignment to post top navigation

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,13 +4,13 @@ layout: default
 
 <div class="container">
 	<div class="row">
-		<div class="col-md-3">
+		<div class="col-md-3 text-left">
 			{% if page.previous %}<h5><a href="{{ page.previous.url }}" title="Previous news: {{ page.previous.title }}"><i class="fa fa-previous fa-lg"></i> Previous</a></h5>{% endif %}
 		</div>
-		<div class="col-md-6">
+		<div class="col-md-6 text-center">
 			<h5><a href="/news" title="Back to news index"><i class="fa fa-home fa-lg"></i> Back to news</a></h5>
 		</div>
-		<div class="col-md-3">
+		<div class="col-md-3 text-right">
 			{% if page.next %}<h5><a href="{{ page.next.url }}" title="Next news: {{ page.next.title }}"><i class="fa fa-next fa-lg"></i> Next</a></h5>{% endif %}
 		</div>
 	</div>


### PR DESCRIPTION
The row spanned the entire width, and three columns were applied, but without text alignment

 - the **back** button wasn't centered on the page
 - the **next** button was somewhere nearer to the center

## Current

![screenshot 2017-12-03 at 08 16 32](https://user-images.githubusercontent.com/697855/33525667-4b687612-d802-11e7-8e1a-8467d58bc684.png)

## Proposed

![screenshot 2017-12-03 at 08 15 33](https://user-images.githubusercontent.com/697855/33525661-2caa246e-d802-11e7-8c06-73f3123afbb2.png)
